### PR TITLE
The deployment target necessary is only 9.0

### DIFF
--- a/ios/flutter_youtube_view.podspec
+++ b/ios/flutter_youtube_view.podspec
@@ -17,6 +17,6 @@ A new Flutter plugin.
   s.dependency 'Flutter'
   s.dependency 'YoutubeKit'
 
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '9.0'
 end
 


### PR DESCRIPTION
YoutubeKit requirements are only 9.0
Giving an 11.0 requirement here, only newest Apple phones will work. We should increase this only if necessary.